### PR TITLE
linkify-it-py 2.1.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,24 +1,25 @@
 {% set name = "linkify-it-py" %}
-{% set version = "2.0.3" %}
+{% set version = "2.1.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 68cda27e162e9215c17d786649d1da0021a451bdc436ef9e0fa0ba5234b9b048
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace("-", "_") }}-{{ version }}.tar.gz
+  sha256: 43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<37]
+  skip: true  # [py<310]
 
 requirements:
   host:
-    - python
     - pip
+    - python
     - setuptools
+    - wheel
   run:
     - python
     - uc-micro-py


### PR DESCRIPTION
linkify-it-py 2.1.0 

**Destination channel:** Defaults

### Links

- [PKG-13376]
- dev_url:        https://github.com/tsutsu3/linkify-it-py/tree/v2.1.0
- conda_forge:    https://github.com/conda-forge/linkify-it-py-feedstock
- pypi:           https://pypi.org/project/linkify-it-py/2.1.0
- pypi inspector: https://inspector.pypi.io/project/linkify-it-py/2.1.0

### Explanation of changes:

- new version number


[PKG-13376]: https://anaconda.atlassian.net/browse/PKG-13376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ